### PR TITLE
Fix: only import the absolutely necessary parts of aws-sdk

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 import { NativeModules } from 'react-native';
-import AWS, { CognitoIdentityServiceProvider } from 'aws-sdk/global';
+import AWS from 'aws-sdk';
+import CognitoIdentityServiceProvider from 'aws-sdk/clients/cognitoidentityserviceprovider';
 import * as enhancements from './src';
 export * from './src';
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import { NativeModules } from 'react-native';
-import AWS, { CognitoIdentityServiceProvider } from 'aws-sdk/dist/aws-sdk-react-native';
+import AWS, { CognitoIdentityServiceProvider } from 'aws-sdk/global';
 import * as enhancements from './src';
 export * from './src';
 

--- a/src/AuthenticationHelper.js
+++ b/src/AuthenticationHelper.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { util } from 'aws-sdk/dist/aws-sdk-react-native';
+import { util } from 'aws-sdk/global';
 
 import BigInteger from './BigInteger';
 

--- a/src/CognitoAccessToken.js
+++ b/src/CognitoAccessToken.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { util } from 'aws-sdk/dist/aws-sdk-react-native';
+import { util } from 'aws-sdk/global';
 
 /** @class */
 export default class CognitoAccessToken {
@@ -24,7 +24,6 @@ export default class CognitoAccessToken {
    * @param {string=} AccessToken The JWT access token.
    */
   constructor({ AccessToken } = {}) {
-    // Assign object
     this.jwtToken = AccessToken || '';
   }
 

--- a/src/CognitoIdToken.js
+++ b/src/CognitoIdToken.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { util } from 'aws-sdk/dist/aws-sdk-react-native';
+import { util } from 'aws-sdk/global';
 
 /** @class */
 export default class CognitoIdToken {

--- a/src/CognitoUser.js
+++ b/src/CognitoUser.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { util } from 'aws-sdk/dist/aws-sdk-react-native';
+import { util } from 'aws-sdk/global';
 
 import BigInteger from './BigInteger';
 import AuthenticationHelper from './AuthenticationHelper';

--- a/src/CognitoUserPool.js
+++ b/src/CognitoUserPool.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { CognitoIdentityServiceProvider } from 'aws-sdk/dist/aws-sdk-react-native';
+import { util } from 'aws-sdk/global';
 
 import CognitoUser from './CognitoUser';
 import StorageHelper from './StorageHelper';


### PR DESCRIPTION
Now that the dependency has been removed on the older, separately bundled react-native aws-sdk bundle, I think it makes sense to rewrite the imports so we're using the normal way to import modules, where we can take advantage of not loading all of the services at once.

Without this, the size of our production bundle went down 50%, more than 2 Mbs.
We are importing classes from from `aws-sdk/global` to reduce the size in our bundle, but the references in `react-native-aws-cognito-js` were referencing the original react-native bundle, and as an end result, both of them were imported.

This probably needs some testing!